### PR TITLE
FBX : Add support for animation importing.

### DIFF
--- a/IONET/Core/Animation/IOAnimation.cs
+++ b/IONET/Core/Animation/IOAnimation.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using IONET.Core.Skeleton;
+
+namespace IONET
+{
+    public class IOAnimation
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public List<IOAnimation> Groups { get; internal set; } = new List<IOAnimation>();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public List<IOAnimationTrack> Tracks { get; internal set; } = new List<IOAnimationTrack>();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float StartFrame { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float EndFrame { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public float CalculateFrameCount()
+        {
+            float frameCount = 0;
+            foreach (var group in Groups)
+                frameCount = Math.Max(frameCount, group.CalculateFrameCount());
+            foreach (var track in Tracks)
+            {
+                //Important to +1 as the frame is the currently played frame in a keyframe
+                var frame = track.KeyFrames.Max(x => x.Frame) + 1;
+                //Get largest key frame value
+                frameCount = Math.Max(frameCount, frame);
+            }
+            return frameCount;
+        }
+    }
+}

--- a/IONET/Core/Animation/IOAnimationTrack.cs
+++ b/IONET/Core/Animation/IOAnimationTrack.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IONET
+{
+    public class IOAnimationTrack
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public IOAnimationTrackType ChannelType { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public List<IOKeyFrame> KeyFrames { get; internal set; } = new List<IOKeyFrame>();
+    }
+}

--- a/IONET/Core/Animation/IOAnimationTrackType.cs
+++ b/IONET/Core/Animation/IOAnimationTrackType.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IONET
+{
+    public enum IOAnimationTrackType
+    {
+        PositionX,
+        PositionY,
+        PositionZ,
+        RotationEulerX,
+        RotationEulerY,
+        RotationEulerZ,
+        QuatX,
+        QuatY,
+        QuatZ,
+        QuatW,
+        ScaleX,
+        ScaleY,
+        ScaleZ,
+        TransformMatrix4x4,
+    }
+}

--- a/IONET/Core/Animation/IOKeyFrame.cs
+++ b/IONET/Core/Animation/IOKeyFrame.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IONET
+{
+    public class IOKeyFrame
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public float Time { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float Frame { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public object Value { get; set; }
+    }
+
+
+    public class IOKeyFrameCubic : IOKeyFrame
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public float TangentInput { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public float TangentOutput { get; set; }
+    }
+
+    public class IOKeyFrameHermite : IOKeyFrame
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public float TangentInput { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public float TangentOutput { get; set; }
+    }
+
+    public class IOKeyFrameBezier : IOKeyFrame
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public float TangentInputX { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float TangentInputY { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float TangentOutputX { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float TangentOutputY { get; set; }
+    }
+}

--- a/IONET/Core/IOScene.cs
+++ b/IONET/Core/IOScene.cs
@@ -22,6 +22,11 @@ namespace IONET.Core
         public List<IOMaterial> Materials { get; internal set; } = new List<IOMaterial>();
 
         /// <summary>
+        /// 
+        /// </summary>
+        public List<IOAnimation> Animations { get; internal set; } = new List<IOAnimation>();
+
+        /// <summary>
         /// Cleans material names to allow for smoother export
         /// </summary>
         public void CleanMaterialNames()


### PR DESCRIPTION
Adds simple support for FBX animations along with updates to the core for animation support. Currently supporting the XYZ SRT targets for animating a node/mesh/limb. This does not currently support tangents used in cubic curves atm. (no idea how to extract the tangents from the attribute flags/data.)

Collada is also planned for importing/exporting and will be a later PR. Has a few more things todo for that to be ready. 