### PR TITLE
Add .anim support and include some improvements.

### DIFF
--- a/IONET/Collada/ColladaExporter.cs
+++ b/IONET/Collada/ColladaExporter.cs
@@ -22,7 +22,7 @@ using System.Xml;
 
 namespace IONET.Collada
 {
-    public class ColladaExporter : IModelExporter
+    public class ColladaExporter : ISceneExporter
     {
         private ExportSettings _settings;
         private IONET.Collada.Collada _collada;

--- a/IONET/Collada/ColladaImporter.cs
+++ b/IONET/Collada/ColladaImporter.cs
@@ -17,7 +17,7 @@ using System.Xml;
 
 namespace IONET.Collada
 {
-    public class ColladaImporter : IModelLoader
+    public class ColladaImporter : ISceneLoader
     {
         /// <summary>
         /// 

--- a/IONET/Core/Animation/IOAnimation.cs
+++ b/IONET/Core/Animation/IOAnimation.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using IONET.Core.Skeleton;
 
-namespace IONET
+namespace IONET.Core.Animation
 {
     public class IOAnimation
     {
@@ -35,12 +34,11 @@ namespace IONET
         /// <summary>
         /// 
         /// </summary>
-        /// <returns></returns>
-        public float CalculateFrameCount()
+        public float GetFrameCount()
         {
             float frameCount = 0;
             foreach (var group in Groups)
-                frameCount = Math.Max(frameCount, group.CalculateFrameCount());
+                frameCount = Math.Max(frameCount, group.GetFrameCount());
             foreach (var track in Tracks)
             {
                 //Important to +1 as the frame is the currently played frame in a keyframe

--- a/IONET/Core/Animation/IOAnimationTrack.cs
+++ b/IONET/Core/Animation/IOAnimationTrack.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IONET
+namespace IONET.Core.Animation
 {
     public class IOAnimationTrack
     {
@@ -12,6 +12,16 @@ namespace IONET
         /// 
         /// </summary>
         public IOAnimationTrackType ChannelType { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public IOCurveWrapMode PreWrap { get; set; } = IOCurveWrapMode.Constant;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public IOCurveWrapMode PostWrap { get; set; } = IOCurveWrapMode.Constant;
 
         /// <summary>
         /// 

--- a/IONET/Core/Animation/IOAnimationTrackType.cs
+++ b/IONET/Core/Animation/IOAnimationTrackType.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IONET
+namespace IONET.Core.Animation
 {
     public enum IOAnimationTrackType
     {
@@ -22,5 +22,6 @@ namespace IONET
         ScaleY,
         ScaleZ,
         TransformMatrix4x4,
+        NodeVisibility,
     }
 }

--- a/IONET/Core/Animation/IOCurveWrapMode.cs
+++ b/IONET/Core/Animation/IOCurveWrapMode.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace IONET.Core.Animation
+{
+    /// <summary>
+    /// Represents a wrap mode to determine how a curve behaves at the start/end key frames.
+    /// </summary>
+    public enum IOCurveWrapMode
+    {
+        /// <summary>
+        /// Stops at first/last key value and stays
+        /// </summary>
+        Constant,
+        /// <summary>
+        /// Moves to the direction of the first/last key frame based on tangent angle
+        /// </summary>
+        Linear,
+        /// <summary>
+        /// Repeats back to first/last key frame
+        /// </summary>
+        Cycle,
+        /// <summary>
+        /// Repeats but starts relative to the first/last key frame
+        /// </summary>
+        CycleRelative,
+        /// <summary>
+        /// Repeats by reversing its values
+        /// </summary>
+        Oscillate,
+    }
+}

--- a/IONET/Core/Animation/IOKeyFrame.cs
+++ b/IONET/Core/Animation/IOKeyFrame.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IONET
+namespace IONET.Core.Animation
 {
     public class IOKeyFrame
     {
@@ -24,29 +24,39 @@ namespace IONET
         public object Value { get; set; }
     }
 
-
-    public class IOKeyFrameCubic : IOKeyFrame
-    {
-        /// <summary>
-        /// 
-        /// </summary>
-        public float TangentInput { get; set; }
-        /// <summary>
-        /// 
-        /// </summary>
-        public float TangentOutput { get; set; }
-    }
-
     public class IOKeyFrameHermite : IOKeyFrame
     {
         /// <summary>
         /// 
         /// </summary>
-        public float TangentInput { get; set; }
+        public float TangentSlopeInput { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public float TangentOutput { get; set; }
+        public float TangentSlopeOutput { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public float TangentWeightInput { get; set; } = 1.0f;
+        /// <summary>
+        /// 
+        /// </summary>
+        public float TangentWeightOutput { get; set; } = 1.0f;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool IsWeighted => (TangentWeightInput != 1.0f || TangentWeightOutput != 1.0f);
+
+        public static IOKeyFrameHermite FromBezier(IOKeyFrameBezier bezier)
+        {
+            return new IOKeyFrameHermite()
+            {
+                Frame = bezier.Frame,
+                Value = bezier.Value,
+            };
+        }
     }
 
     public class IOKeyFrameBezier : IOKeyFrame

--- a/IONET/Core/IOScene.cs
+++ b/IONET/Core/IOScene.cs
@@ -1,4 +1,5 @@
 ﻿using IONET.Core.Model;
+using IONET.Core.Animation;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 

--- a/IONET/Core/ISceneExporter.cs
+++ b/IONET/Core/ISceneExporter.cs
@@ -1,6 +1,6 @@
 ﻿namespace IONET.Core
 {
-    public interface IModelExporter
+    public interface ISceneExporter
     {
         string Name();
 

--- a/IONET/Core/ISceneLoader.cs
+++ b/IONET/Core/ISceneLoader.cs
@@ -1,6 +1,6 @@
 ﻿namespace IONET.Core
 {
-    public interface IModelLoader
+    public interface ISceneLoader
     {
         string Name();
 

--- a/IONET/Fbx/FbxImporter.cs
+++ b/IONET/Fbx/FbxImporter.cs
@@ -5,7 +5,7 @@ using System.IO;
 
 namespace IONET.Fbx
 {
-    public class FbxImporter : IModelLoader
+    public class FbxImporter : ISceneLoader
     {
         /// <summary>
         /// 

--- a/IONET/IOManager.cs
+++ b/IONET/IOManager.cs
@@ -3,6 +3,7 @@ using IONET.Core;
 using IONET.Fbx;
 using IONET.SMD;
 using IONET.Wavefront;
+using IONET.MayaAnim;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -14,24 +15,26 @@ namespace IONET
         /// <summary>
         /// 
         /// </summary>
-        private static IModelLoader[] ModelLoaders = new
-            IModelLoader[]
+        private static ISceneLoader[] SceneLoaders = new
+            ISceneLoader[]
         {
             new ColladaImporter(),
             new SMDImporter(),
             new OBJImporter(),
-            new FbxImporter()
+            new FbxImporter(),
+            new MayaAnimImporter(),
         };
 
         /// <summary>
         /// 
         /// </summary>
-        private static IModelExporter[] ModelExporters = new
-            IModelExporter[]
+        private static ISceneExporter[] SceneExporters = new
+            ISceneExporter[]
         {
             new ColladaExporter(),
             new SMDExporter(),
-            new OBJExporter()
+            new OBJExporter(),
+            new MayaAnimExporter(),
         };
 
         /// <summary>
@@ -42,11 +45,11 @@ namespace IONET
         {
             StringBuilder sb = new StringBuilder();
 
-            var allExt = string.Join(";*", ModelExporters.SelectMany(e => e.GetExtensions()));
+            var allExt = string.Join(";*", SceneExporters.SelectMany(e => e.GetExtensions()));
 
             sb.Append($"Supported Files (*{allExt})|*{allExt}");
 
-            foreach(var l in ModelExporters)
+            foreach(var l in SceneExporters)
             {
                 var ext = string.Join(";*", l.GetExtensions());
                 sb.Append($"|{l.Name()} (*{ext})|*{ext}");
@@ -65,11 +68,11 @@ namespace IONET
         {
             StringBuilder sb = new StringBuilder();
 
-            var allExt = string.Join(";*", ModelLoaders.SelectMany(e => e.GetExtensions()));
+            var allExt = string.Join(";*", SceneLoaders.SelectMany(e => e.GetExtensions()));
 
             sb.Append($"Supported Files (*{allExt})|*{allExt}");
 
-            foreach (var l in ModelLoaders)
+            foreach (var l in SceneLoaders)
             {
                 var ext = string.Join(";*", l.GetExtensions());
                 sb.Append($"|{l.Name()} (*{ext})|*{ext}");
@@ -87,7 +90,7 @@ namespace IONET
         /// <returns></returns>
         public static IOScene LoadScene(string filePath, ImportSettings settings)
         {
-            foreach(var l in ModelLoaders)
+            foreach(var l in SceneLoaders)
                 if (l.Verify(filePath))
                 {
                     var scene = l.GetScene(filePath);
@@ -171,7 +174,7 @@ namespace IONET
             if (settings == null)
                 settings = new ExportSettings();
 
-            foreach (var l in ModelExporters)
+            foreach (var l in SceneExporters)
                 foreach (var e in l.GetExtensions())
                     if (e.Equals(ext))
                     {

--- a/IONET/MayaAnim/MayaAnim.cs
+++ b/IONET/MayaAnim/MayaAnim.cs
@@ -1,0 +1,534 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ComponentModel;
+using System.IO;
+using IONET.Core.Skeleton;
+using IONET.Core.Animation;
+
+namespace IONET.MayaAnim
+{
+    public class MayaAnim
+    {
+        private enum InfinityType
+        {
+            constant,
+            linear,
+            cycle,
+            cycleRelative,
+            oscillate
+        }
+
+        private enum InputType
+        {
+            time,
+            unitless
+        }
+
+        private enum OutputType
+        {
+            time,
+            linear,
+            angular,
+            unitless
+        }
+
+        private enum ControlType
+        {
+            translate,
+            rotate,
+            scale,
+            visibility
+        }
+
+        private enum TrackType
+        {
+            translateX,
+            translateY,
+            translateZ,
+            rotateX,
+            rotateY,
+            rotateZ,
+            scaleX,
+            scaleY,
+            scaleZ,
+            visibility
+        }
+
+        private class Header
+        {
+            public float animVersion;
+            public string mayaVersion;
+            public float startTime;
+            public float endTime;
+            public float startUnitless;
+            public float endUnitless;
+            public string timeUnit;
+            public string linearUnit;
+            public string angularUnit;
+
+            public Header()
+            {
+                animVersion = 1.1f;
+                mayaVersion = "2015";
+                startTime = 1;
+                endTime = 1;
+                startUnitless = 0;
+                endUnitless = 0;
+                timeUnit = "ntscf";
+                linearUnit = "cm";
+                angularUnit = "rad";
+            }
+        }
+
+        private class AnimKey
+        {
+            public float input, output;
+            public string intan, outtan;
+            public float t1 = 0, w1 = 1;
+            public float t2 = 0, w2 = 1;
+
+            public AnimKey()
+            {
+                intan = "linear";
+                outtan = "linear";
+            }
+        }
+
+        private class AnimData
+        {
+            public ControlType controlType;
+            public TrackType type;
+            public InputType input;
+            public OutputType output;
+            public InfinityType preInfinity, postInfinity;
+            public bool weighted = false;
+            public List<AnimKey> keys = new List<AnimKey>();
+
+            public AnimData()
+            {
+                input = InputType.time;
+                output = OutputType.linear;
+                preInfinity = InfinityType.constant;
+                postInfinity = InfinityType.constant;
+                weighted = false;
+            }
+        }
+
+        private class AnimBone
+        {
+            public string name;
+            public List<AnimData> atts = new List<AnimData>();
+        }
+
+        private Header header;
+        private List<AnimBone> Bones = new List<AnimBone>();
+
+        public string Name = "Animation";
+
+        public MayaAnim()
+        {
+            header = new Header();
+        }
+
+        public void Open(string fileName)
+        {
+            Name = Path.GetFileNameWithoutExtension(fileName);
+            using (StreamReader r = new StreamReader(new FileStream(fileName, FileMode.Open)))
+            {
+                AnimData currentData = null;
+                while (!r.EndOfStream)
+                {
+                    var line = r.ReadLine();
+                    var args = line.Trim().Replace(";", "").Split(' ');
+
+                    switch (args[0])
+                    {
+                        case "animVersion":
+                            header.animVersion = float.Parse(args[1]);
+                            break;
+                        case "mayaVersion":
+                            header.mayaVersion = args[1];
+                            break;
+                        case "timeUnit":
+                            header.timeUnit = args[1];
+                            break;
+                        case "linearUnit":
+                            header.linearUnit = args[1];
+                            break;
+                        case "angularUnit":
+                            header.angularUnit = args[1];
+                            break;
+                        case "startTime":
+                            header.startTime = float.Parse(args[1]);
+                            break;
+                        case "endTime":
+                            header.endTime = float.Parse(args[1]);
+                            break;
+                        case "anim":
+                            if (args.Length != 7)
+                                continue;
+                            var currentNode = Bones.Find(e => e.name.Equals(args[3]));
+                            if (currentNode == null)
+                            {
+                                currentNode = new AnimBone();
+                                currentNode.name = args[3];
+                                Bones.Add(currentNode);
+                            }
+                            currentData = new AnimData();
+                            currentData.controlType = (ControlType)Enum.Parse(typeof(ControlType), args[1].Split('.')[0]);
+                            currentData.type = (TrackType)Enum.Parse(typeof(TrackType), args[2]);
+                            currentNode.atts.Add(currentData);
+                            break;
+                        case "animData":
+                            if (currentData == null)
+                                continue;
+                            string dataLine = r.ReadLine();
+                            while (!dataLine.Contains("}"))
+                            {
+                                var dataArgs = dataLine.Trim().Replace(";", "").Split(' ');
+                                switch (dataArgs[0])
+                                {
+                                    case "input":
+                                        currentData.input = (InputType)Enum.Parse(typeof(InputType), dataArgs[1]);
+                                        break;
+                                    case "output":
+                                        currentData.output = (OutputType)Enum.Parse(typeof(OutputType), dataArgs[1]);
+                                        break;
+                                    case "weighted":
+                                        currentData.weighted = dataArgs[1] == "1";
+                                        break;
+                                    case "preInfinity":
+                                        currentData.preInfinity = (InfinityType)Enum.Parse(typeof(InfinityType), dataArgs[1]);
+                                        break;
+                                    case "postInfinity":
+                                        currentData.postInfinity = (InfinityType)Enum.Parse(typeof(InfinityType), dataArgs[1]);
+                                        break;
+                                    case "keys":
+                                        string keyLine = r.ReadLine();
+                                        while (!keyLine.Contains("}"))
+                                        {
+                                            var keyArgs = keyLine.Trim().Replace(";", "").Split(' ');
+
+                                            var key = new AnimKey()
+                                            {
+                                                input = float.Parse(keyArgs[0]),
+                                                output = float.Parse(keyArgs[1])
+                                            };
+
+                                            if (keyArgs.Length >= 7)
+                                            {
+                                                key.intan = keyArgs[2];
+                                                key.outtan = keyArgs[3];
+                                            }
+
+                                            if (key.intan == "fixed")
+                                            {
+                                                key.t1 = float.Parse(keyArgs[7]);
+                                                key.w1 = float.Parse(keyArgs[8]);
+                                            }
+                                            if (key.outtan == "fixed" && keyArgs.Length > 9)
+                                            {
+                                                key.t2 = float.Parse(keyArgs[9]);
+                                                key.w2 = float.Parse(keyArgs[10]);
+                                            }
+
+                                            currentData.keys.Add(key);
+
+                                            keyLine = r.ReadLine();
+                                        }
+                                        break;
+
+                                }
+                                dataLine = r.ReadLine();
+                            }
+                            break;
+                    }
+                }
+            }
+        }
+
+        public void Save(string fileName)
+        {
+            using (System.IO.StreamWriter file = new System.IO.StreamWriter(fileName))
+            {
+                file.WriteLine("animVersion " + header.animVersion + ";");
+                file.WriteLine("mayaVersion " + header.mayaVersion + ";");
+                file.WriteLine("timeUnit " + header.timeUnit + ";");
+                file.WriteLine("linearUnit " + header.linearUnit + ";");
+                file.WriteLine("angularUnit " + header.angularUnit + ";");
+                file.WriteLine("startTime " + 1 + ";");
+                file.WriteLine("endTime " + header.endTime + ";");
+
+                int Row = 0;
+
+                foreach (AnimBone animBone in Bones)
+                {
+                    int TrackIndex = 0;
+                    if (animBone.atts.Count == 0)
+                    {
+                        file.WriteLine($"anim {animBone.name} 0 1 {TrackIndex++};");
+                    }
+                    foreach (AnimData animData in animBone.atts)
+                    {
+                        file.WriteLine($"anim {animData.controlType}.{animData.type} {animData.type} {animBone.name} 0 1 {TrackIndex++};");
+                        file.WriteLine("animData {");
+                        file.WriteLine($" input {animData.input};");
+                        file.WriteLine($" output {animData.output};");
+                        file.WriteLine($" weighted {(animData.weighted ? 1 : 0)};");
+                        file.WriteLine($" preInfinity {animData.preInfinity};");
+                        file.WriteLine($" postInfinity {animData.postInfinity};");
+
+                        file.WriteLine(" keys {");
+                        foreach (AnimKey key in animData.keys)
+                        {
+                            // TODO: fixed splines
+                            string tanin = key.intan == "fixed" ? " " + key.t1 + " " + key.w1 : "";
+                            string tanout = key.outtan == "fixed" ? " " + key.t2 + " " + key.w2 : "";
+                            file.WriteLine($" {key.input} {key.output:N6} {key.intan} {key.outtan} 1 1 0{tanin}{tanout};");
+                        }
+                        file.WriteLine(" }");
+
+                        file.WriteLine("}");
+                    }
+                    Row++;
+                }
+            }
+        }
+
+        public static IOAnimation ImportAnimation(string filePath, ImportSettings settings)
+        {
+            var anim = new MayaAnim();
+            anim.Open(filePath);
+            return anim.GetAnimation();
+        }
+
+        public IOAnimation GetAnimation()
+        {
+            IOAnimation anim = new IOAnimation();
+            anim.Name = this.Name;
+            foreach (var mayaAnimBone in this.Bones)
+            {
+                IOAnimation animBone = new IOAnimation();
+                animBone.Name = mayaAnimBone.name;
+                anim.Groups.Add(animBone);
+
+                foreach (var att in mayaAnimBone.atts)
+                    animBone.Tracks.Add(GetTrack(att));
+            }
+            return anim;
+        }
+
+        private IOAnimationTrack GetTrack(AnimData data)
+        {
+            IOAnimationTrack track = new IOAnimationTrack();
+            switch (data.type)
+            {
+                case TrackType.translateX: track.ChannelType = IOAnimationTrackType.PositionX; break;
+                case TrackType.translateY: track.ChannelType = IOAnimationTrackType.PositionY; break;
+                case TrackType.translateZ: track.ChannelType = IOAnimationTrackType.PositionZ; break;
+                case TrackType.rotateX: track.ChannelType = IOAnimationTrackType.RotationEulerX; break;
+                case TrackType.rotateY: track.ChannelType = IOAnimationTrackType.RotationEulerY; break;
+                case TrackType.rotateZ: track.ChannelType = IOAnimationTrackType.RotationEulerZ; break;
+                case TrackType.scaleX: track.ChannelType = IOAnimationTrackType.ScaleX; break;
+                case TrackType.scaleY: track.ChannelType = IOAnimationTrackType.ScaleY; break;
+                case TrackType.scaleZ: track.ChannelType = IOAnimationTrackType.ScaleZ; break;
+                case TrackType.visibility: track.ChannelType = IOAnimationTrackType.NodeVisibility; break;
+            }
+            track.PreWrap = CurveWrapModes.FirstOrDefault(x => x.Value == data.preInfinity).Key;
+            track.PostWrap = CurveWrapModes.FirstOrDefault(x => x.Value == data.postInfinity).Key;
+
+            foreach (var key in data.keys)
+            {
+                if (key.intan == "fixed" || key.outtan == "fixed")
+                {
+                    track.KeyFrames.Add(new IOKeyFrameHermite()
+                    {
+                        Frame = key.input - header.startTime,
+                        Value = GetOutputValue(this, data, key.output),
+                        TangentSlopeInput = key.t1,
+                        TangentSlopeOutput = key.t2,
+                        TangentWeightInput = key.w1,
+                        TangentWeightOutput = key.w2,
+                    });
+                }
+                else
+                {
+                    track.KeyFrames.Add(new IOKeyFrame()
+                    {
+                        Frame = key.input - header.startTime,
+                        Value = GetOutputValue(this, data, key.output),
+                    });
+                }
+            }
+
+            return track;
+        }
+
+        static Dictionary<IOCurveWrapMode, InfinityType> CurveWrapModes = new Dictionary<IOCurveWrapMode, InfinityType>()
+        {
+            { IOCurveWrapMode.Constant, InfinityType.constant },
+            { IOCurveWrapMode.Linear, InfinityType.linear },
+            { IOCurveWrapMode.Cycle, InfinityType.cycle },
+            { IOCurveWrapMode.CycleRelative, InfinityType.cycleRelative },
+            { IOCurveWrapMode.Oscillate, InfinityType.oscillate },
+        };
+
+        private float GetOutputValue(MayaAnim anim, AnimData data, float value)
+        {
+            if (data.output == OutputType.angular)
+            {
+                if (anim.header.angularUnit == "deg")
+                    return (float)(value * Math.PI / 180);
+            }
+            return value;
+        }
+
+        public static void ExportAnimation(string filePath, ExportSettings settings, IOAnimation animation, IOSkeleton skeleton)
+        {
+            var anim = CreateMayaAnimation(settings, animation, skeleton);
+            anim.Save(filePath);
+        }
+
+        static MayaAnim CreateMayaAnimation(ExportSettings settings, IOAnimation animation, IOSkeleton skeleton)
+        {
+            MayaAnim anim = new MayaAnim();
+            anim.header.startTime = 0;
+            anim.header.endTime = animation.GetFrameCount();
+
+            bool is2015 = false;
+
+            // get bone order
+            List<IOBone> BonesInOrder = getBoneTreeOrder(skeleton);
+            if (is2015)
+                BonesInOrder = BonesInOrder.OrderBy(f => f.Name, StringComparer.Ordinal).ToList();
+
+            foreach (IOBone b in BonesInOrder)
+            {
+                AnimBone animBone = new AnimBone()
+                {
+                    name = b.Name
+                };
+                anim.Bones.Add(animBone);
+
+                var group = animation.Groups.FirstOrDefault(x => x.Name.Equals(b.Name));
+                if (group == null)
+                    continue;
+
+                foreach (var track in group.Tracks)
+                {
+                    switch (track.ChannelType)
+                    {
+                        case IOAnimationTrackType.PositionX:
+                            AddAnimData(settings, animBone, track, ControlType.translate, TrackType.translateX);
+                            break;
+                        case IOAnimationTrackType.PositionY:
+                            AddAnimData(settings, animBone, track, ControlType.translate, TrackType.translateY);
+                            break;
+                        case IOAnimationTrackType.PositionZ:
+                            AddAnimData(settings, animBone, track, ControlType.translate, TrackType.translateZ);
+                            break;
+                        case IOAnimationTrackType.RotationEulerX:
+                            AddAnimData(settings, animBone, track, ControlType.rotate, TrackType.rotateX);
+                            break;
+                        case IOAnimationTrackType.RotationEulerY:
+                            AddAnimData(settings, animBone, track, ControlType.rotate, TrackType.rotateY);
+                            break;
+                        case IOAnimationTrackType.RotationEulerZ:
+                            AddAnimData(settings, animBone, track, ControlType.rotate, TrackType.rotateZ);
+                            break;
+                        case IOAnimationTrackType.ScaleX:
+                            AddAnimData(settings, animBone, track, ControlType.scale, TrackType.scaleX);
+                            break;
+                        case IOAnimationTrackType.ScaleY:
+                            AddAnimData(settings, animBone, track, ControlType.scale, TrackType.scaleY);
+                            break;
+                        case IOAnimationTrackType.ScaleZ:
+                            AddAnimData(settings, animBone, track, ControlType.scale, TrackType.scaleZ);
+                            break;
+                    }
+                }
+            }
+            return anim;
+        }
+
+        static void AddAnimData(ExportSettings settings, AnimBone animBone, IOAnimationTrack track, ControlType ctype, TrackType ttype)
+        {
+            AnimData d = new AnimData();
+            d.controlType = ctype;
+            d.type = ttype;
+            d.preInfinity = CurveWrapModes[track.PreWrap];
+            d.postInfinity = CurveWrapModes[track.PostWrap];
+            //Check if any tangents include weights.
+            d.weighted = track.KeyFrames.Any(x => x is IOKeyFrameHermite && ((IOKeyFrameHermite)x).IsWeighted);
+
+            bool isAngle = ctype == ControlType.rotate;
+            if (isAngle)
+                d.output = OutputType.angular;
+
+            float value = track.KeyFrames.Count > 0 ? (float)track.KeyFrames[0].Value : 0;
+
+            bool IsConstant = true;
+            foreach (var key in track.KeyFrames)
+            {
+                if ((float)key.Value != value) {
+                    IsConstant = false;
+                    break;
+                }
+            }
+            foreach (var key in track.KeyFrames)
+            {
+                AnimKey animKey = new AnimKey()
+                {
+                    input = key.Frame + 1,
+                    output = isAngle ? GetAngle(settings, (float)key.Value) : (float)key.Value,
+                };
+                if (key is IOKeyFrameHermite)
+                {
+                    animKey.intan = "fixed";
+                    animKey.outtan = "fixed";
+                    animKey.t1 = ((IOKeyFrameHermite)key).TangentSlopeInput;
+                    animKey.t2 = ((IOKeyFrameHermite)key).TangentSlopeOutput;
+                    animKey.w1 = ((IOKeyFrameHermite)key).TangentWeightInput;
+                    animKey.w2 = ((IOKeyFrameHermite)key).TangentWeightOutput;
+                }
+                d.keys.Add(animKey);
+                if (IsConstant)
+                    break;
+            }
+
+            if (d.keys.Count > 0)
+                animBone.atts.Add(d);
+        }
+
+        private static float GetAngle(ExportSettings settings, float value) {
+            return (settings.MayaAnimUseRadians ? value : (float)(value * (180 / Math.PI)));
+        }
+
+        private static List<IOBone> getBoneTreeOrder(IOSkeleton Skeleton)
+        {
+            if (Skeleton.RootBones.Count == 0)
+                return null;
+            List<IOBone> bone = new List<IOBone>();
+            Queue<IOBone> q = new Queue<IOBone>();
+
+            foreach (IOBone b in Skeleton.RootBones)
+            {
+                QueueBones(b, q, Skeleton);
+            }
+
+            while (q.Count > 0)
+            {
+                bone.Add(q.Dequeue());
+            }
+            return bone;
+        }
+
+        public static void QueueBones(IOBone b, Queue<IOBone> q, IOSkeleton Skeleton)
+        {
+            q.Enqueue(b);
+            foreach (IOBone c in b.Children)
+                QueueBones(c, q, Skeleton);
+        }
+    }
+}

--- a/IONET/MayaAnim/MayaAnimExporter.cs
+++ b/IONET/MayaAnim/MayaAnimExporter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using IONET.Core;
+
+namespace IONET.MayaAnim
+{
+    class MayaAnimExporter : ISceneExporter
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <returns></returns>
+        public void ExportScene(IOScene scene, string filePath, ExportSettings settings)
+        {
+            if (scene.Models.Count == 0)
+                throw new Exception($"Failed to export animation! Model must have a skeleton to export!");
+
+            MayaAnim.ExportAnimation(filePath, settings, 
+                scene.Animations[0], 
+                scene.Models[0].Skeleton);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public string[] GetExtensions() => new string[] { ".anim" };
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public string Name() => "Autodesk Maya Anim";
+    }
+}

--- a/IONET/MayaAnim/MayaAnimImporter.cs
+++ b/IONET/MayaAnim/MayaAnimImporter.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using IONET.Core;
+
+namespace IONET.MayaAnim
+{
+    class MayaAnimImporter : ISceneLoader
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <returns></returns>
+        public IOScene GetScene(string filePath)
+        {
+            IOScene scene = new IOScene();
+            scene.Animations.Add(MayaAnim.ImportAnimation(filePath, new ImportSettings()));
+            return scene;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public string[] GetExtensions() => new string[] { ".anim" };
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public string Name() => "Autodesk Maya Anim";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <returns></returns>
+        public bool Verify(string filePath) {
+            return Path.GetExtension(filePath).ToLower().Equals(".anim");
+        }
+    }
+}

--- a/IONET/SMD/SMDExporter.cs
+++ b/IONET/SMD/SMDExporter.cs
@@ -6,7 +6,7 @@ using System.Numerics;
 
 namespace IONET.SMD
 {
-    public class SMDExporter : IModelExporter
+    public class SMDExporter : ISceneExporter
     {
         /// <summary>
         /// 

--- a/IONET/SMD/SMDImporter.cs
+++ b/IONET/SMD/SMDImporter.cs
@@ -10,7 +10,7 @@ namespace IONET.SMD
     /// <summary>
     /// 
     /// </summary>
-    public class SMDImporter : IModelLoader
+    public class SMDImporter : ISceneLoader
     {
         /// <summary>
         /// 

--- a/IONET/Settings.cs
+++ b/IONET/Settings.cs
@@ -97,5 +97,16 @@ namespace IONET
         [Category("Misc"), DisplayName("Blender Mode"), Description("Helps with blender compatibility (DAE ONLY)")]
         public bool BlenderMode { get; set; } = true;
 
+        /// <summary>
+        /// 
+        /// </summary>
+        [Category("Anim"), DisplayName("Maya 2015 (.anim)"), Description("Helps with Maya 2015 compatibility (ANIM ONLY)")]
+        public bool MayaAnim2015 { get; set; } = true;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Category("Anim"), DisplayName("Use Radians (.anim)"), Description("Determines to use radians for maya animations. (ANIM ONLY)")]
+        public bool MayaAnimUseRadians { get; set; } = true;
     }
 }

--- a/IONET/Wavefront/OBJExporter.cs
+++ b/IONET/Wavefront/OBJExporter.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace IONET.Wavefront
 {
-    public class OBJExporter : IModelExporter
+    public class OBJExporter : ISceneExporter
     {
         /// <summary>
         /// 

--- a/IONET/Wavefront/OBJImporter.cs
+++ b/IONET/Wavefront/OBJImporter.cs
@@ -8,7 +8,7 @@ using System.Text.RegularExpressions;
 
 namespace IONET.Wavefront
 {
-    public class OBJImporter : IModelLoader
+    public class OBJImporter : ISceneLoader
     {
         /// <summary>
         /// 


### PR DESCRIPTION
Adds support for pre/post wrapping modes.
Adds support for .anim import/exporting (used from StudioSB which has an excellent reader/writer).
Adds support for weighted tangents.
Load in fbx tangent data.
The animation IO is in its own proper namespace.

![image](https://user-images.githubusercontent.com/13475262/146091125-af8206ac-3279-408b-90dd-86706cf785a9.png)

An example of something exported with .dae model + .anim.