### PR TITLE
Improve OBJ parsing. Adjust maya .anim setting.

### DIFF
--- a/IONET/Settings.cs
+++ b/IONET/Settings.cs
@@ -101,7 +101,7 @@ namespace IONET
         /// 
         /// </summary>
         [Category("Anim"), DisplayName("Maya 2015 (.anim)"), Description("Helps with Maya 2015 compatibility (ANIM ONLY)")]
-        public bool MayaAnim2015 { get; set; } = true;
+        public bool MayaAnim2015 { get; set; } = false;
 
         /// <summary>
         /// 


### PR DESCRIPTION
- Fixed obj files with no tex coords.
- Fixed loading obj files from different format providers expecting commas over periods. 
- Fixed a case where indices would not parse due to spacing.
- Maya 2015 setting disabled unless set by user as it is limited to that version of Maya. 